### PR TITLE
Add document CRUD

### DIFF
--- a/src/app/documents/page.tsx
+++ b/src/app/documents/page.tsx
@@ -1,0 +1,8 @@
+import DocumentComponent from "@/components/DocumentComponent";
+import DocumentService from "@/services/DocumentService";
+
+export default async function DocumentsPage() {
+    const documents = await DocumentService.getAll();
+
+    return <DocumentComponent documents={documents} />;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,8 @@ export default function Home() {
                 <Link href={'/contrats'}>Contrats</Link>
                 <br/>
                 <Link href={'/appartements'}>Appartements</Link>
+                <br/>
+                <Link href={'/documents'}>Documents</Link>
             </li>
         </ul>
     </>

--- a/src/components/AddDocumentComponent.tsx
+++ b/src/components/AddDocumentComponent.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Form, Input, Modal } from "antd";
+import { useEffect } from "react";
+import Document from "@/models/Document";
+
+interface Props {
+    document: Document;
+    onClose: () => void;
+    onSubmit: (document: Document) => void;
+}
+
+export default function AddDocumentComponent({ document, onClose, onSubmit }: Props) {
+    const [form] = Form.useForm();
+
+    useEffect(() => {
+        form.setFieldsValue(document);
+    }, [form, document]);
+
+    const handleOk = () => {
+        form
+            .validateFields()
+            .then((values) => {
+                const updated: Document = { ...document, ...values };
+                onSubmit(updated);
+            })
+            .catch(() => {});
+    };
+
+    return (
+        <Modal
+            title={document.id ? "Modifier le document" : "Ajouter un document"}
+            open={true}
+            onCancel={onClose}
+            onOk={handleOk}
+            okText="Valider"
+            cancelText="Annuler"
+        >
+            <Form form={form} layout="vertical">
+                <Form.Item name="nom" label="Nom" rules={[{ required: true, message: "Le nom est obligatoire." }]}> 
+                    <Input />
+                </Form.Item>
+                <Form.Item name="url" label="URL" rules={[{ required: true, message: "L'URL est obligatoire." }]}> 
+                    <Input />
+                </Form.Item>
+                <Form.Item name="description" label="Description">
+                    <Input.TextArea rows={3} />
+                </Form.Item>
+            </Form>
+        </Modal>
+    );
+}

--- a/src/components/DocumentComponent.tsx
+++ b/src/components/DocumentComponent.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState } from "react";
+import { Button, Table, message } from "antd";
+import { DeleteOutlined, EditOutlined } from "@ant-design/icons";
+import Document from "@/models/Document";
+import DocumentService from "@/services/DocumentService";
+import AddDocumentComponent from "@/components/AddDocumentComponent";
+import Link from "next/link";
+
+export default function DocumentComponent({ documents: initialDocuments }: { documents: Document[] }) {
+    const [documents, setDocuments] = useState<Document[]>(initialDocuments);
+    const [showDialog, setShowDialog] = useState(false);
+    const [documentToEdit, setDocumentToEdit] = useState<Document | null>(null);
+
+    const handleSubmit = async (doc: Document) => {
+        try {
+            const isEdit = !!doc.id;
+            let updated;
+            if (isEdit) {
+                updated = await DocumentService.update(doc.id, doc);
+                setDocuments(documents.map((d) => (d.id === updated.id ? updated : d)));
+                message.success("Document modifié.");
+            } else {
+                updated = await DocumentService.create(doc);
+                setDocuments([...documents, updated]);
+                message.success("Document ajouté.");
+            }
+            setShowDialog(false);
+            setDocumentToEdit(null);
+        } catch (err) {
+            console.error(err);
+            message.error("Erreur lors de l'enregistrement.");
+        }
+    };
+
+    const handleDelete = async (id: number) => {
+        try {
+            await DocumentService.delete(id);
+            setDocuments(documents.filter((d) => d.id !== id));
+            message.success("Document supprimé.");
+        } catch (error) {
+            console.error("Erreur suppression :", error);
+            message.error("Suppression impossible.");
+        }
+    };
+
+    const columns = [
+        {
+            title: "Nom",
+            dataIndex: "nom",
+            key: "nom",
+        },
+        {
+            title: "Description",
+            dataIndex: "description",
+            key: "description",
+        },
+        {
+            title: "URL",
+            dataIndex: "url",
+            key: "url",
+            render: (url: string) => (
+                <a href={url} target="_blank" rel="noopener noreferrer">
+                    {url}
+                </a>
+            ),
+        },
+        {
+            title: "Actions",
+            key: "actions",
+            render: (_: any, record: Document) => (
+                <>
+                    <Button
+                        shape="circle"
+                        onClick={() => {
+                            setDocumentToEdit(record);
+                            setShowDialog(true);
+                        }}
+                    >
+                        <EditOutlined />
+                    </Button>
+                    <Button
+                        shape="circle"
+                        danger
+                        onClick={() => handleDelete(record.id)}
+                    >
+                        <DeleteOutlined />
+                    </Button>
+                </>
+            ),
+        },
+    ];
+
+    return (
+        <>
+            <h2 className="text-2xl font-semibold mb-4">Documents</h2>
+
+            <Button
+                type="primary"
+                className="mb-4"
+                onClick={() => {
+                    setDocumentToEdit(null);
+                    setShowDialog(true);
+                }}
+            >
+                Ajouter un document
+            </Button>
+
+            {showDialog && (
+                <AddDocumentComponent
+                    document={
+                        documentToEdit || {
+                            id: 0,
+                            nom: "",
+                            url: "",
+                            description: "",
+                        }
+                    }
+                    onClose={() => {
+                        setShowDialog(false);
+                        setDocumentToEdit(null);
+                    }}
+                    onSubmit={handleSubmit}
+                />
+            )}
+
+            <Table dataSource={documents} rowKey="id" columns={columns} />
+
+            <div className="mt-4">
+                <Link href="/">
+                    <Button>Retour à l'accueil</Button>
+                </Link>
+            </div>
+        </>
+    );
+}

--- a/src/constants/ApiUrl.ts
+++ b/src/constants/ApiUrl.ts
@@ -6,7 +6,8 @@ const API_URL={
     appartements: `${API_BASE}appartements/`,
     appartementsByBatiment: `${API_BASE}appartements/batiment/`,
     contrats: `${API_BASE}contrats/`,
-    locataires: `${API_BASE}locataires/`
+    locataires: `${API_BASE}locataires/`,
+    documents: `${API_BASE}documents/`
 
 
 };

--- a/src/models/Document.ts
+++ b/src/models/Document.ts
@@ -1,0 +1,6 @@
+export default interface Document {
+    id: number;
+    nom: string;
+    url: string;
+    description: string;
+}

--- a/src/services/DocumentService.ts
+++ b/src/services/DocumentService.ts
@@ -1,0 +1,33 @@
+import HttpService from "./HttpService";
+import API_URL from "@/constants/ApiUrl";
+import Document from "@/models/Document";
+
+const DocumentService = {
+    getAll: async (): Promise<Document[]> => {
+        try {
+            const response = await HttpService.get(API_URL.documents);
+            return Array.isArray(response) ? response : response.data || [];
+        } catch (error) {
+            console.error("Erreur lors de la récupération des documents :", error);
+            return [];
+        }
+    },
+
+    getById: async (id: number): Promise<Document> => {
+        return await HttpService.get(`${API_URL.documents}${id}`);
+    },
+
+    create: async (data: Omit<Document, "id">): Promise<Document> => {
+        return await HttpService.post(API_URL.documents, data);
+    },
+
+    update: async (id: number, data: Document): Promise<Document> => {
+        return await HttpService.put(`${API_URL.documents}${id}`, data);
+    },
+
+    delete: async (id: number): Promise<boolean> => {
+        return await HttpService.delete(`${API_URL.documents}${id}`);
+    }
+};
+
+export default DocumentService;


### PR DESCRIPTION
## Summary
- add Document model and API url
- add Document service
- add dialog and table components for documents
- add documents page and link from homepage

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f1c1d19c832e93aba7dcf14060ff